### PR TITLE
Refactor Tests & GetWarzoneStatsAsync

### DIFF
--- a/src/ModernWarfare.Net/Helpers/ApiHelper.cs
+++ b/src/ModernWarfare.Net/Helpers/ApiHelper.cs
@@ -3,13 +3,12 @@ using System.Net.Http.Headers;
 
 namespace ModernWarfare.Net.Helpers
 {
-    public class ApiHelper
+    public static class ApiHelper
     {
-        public static HttpClient ApiClient { get; set; }
+        public static HttpClient ApiClient { get; set; } = new HttpClient();
 
-        public static void InitializeClient()
+        static ApiHelper()
         {
-            ApiClient = new HttpClient();
             ApiClient.DefaultRequestHeaders.Accept.Clear();
             ApiClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }

--- a/src/ModernWarfare.Net/Helpers/ApiProcessor.cs
+++ b/src/ModernWarfare.Net/Helpers/ApiProcessor.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace ModernWarfare.Net.Helpers
 {
     public class ApiProcessor
     {
-
         public static async Task<Stream> GetUser(string apiUrl)
         {
             var jsonAsStream = await ApiHelper.ApiClient.GetStreamAsync(apiUrl);

--- a/src/ModernWarfare.Net/Helpers/JsonHelper.cs
+++ b/src/ModernWarfare.Net/Helpers/JsonHelper.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ModernWarfare.Net.Helpers
+{
+    internal class JsonHelper
+    {
+        internal Task<T> Deserialise<T>(Stream stream)
+        {
+            var streamReader = new StreamReader(stream);
+            var jsonTextReader = new JsonTextReader(streamReader);
+            var jsonSerializer = new JsonSerializer();
+
+            return Task.FromResult(jsonSerializer.Deserialize<T>(jsonTextReader));
+        }
+    }
+}

--- a/src/ModernWarfare.Net/Models/Multiplayer/Data.cs
+++ b/src/ModernWarfare.Net/Models/Multiplayer/Data.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace ModernWarfare.Net.Models.Multiplayer

--- a/src/ModernWarfare.Net/Models/Multiplayer/Metadata.cs
+++ b/src/ModernWarfare.Net/Models/Multiplayer/Metadata.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace ModernWarfare.Net.Models.Multiplayer
 {

--- a/src/ModernWarfare.Net/Models/Multiplayer/MultiplayerApiOutput.cs
+++ b/src/ModernWarfare.Net/Models/Multiplayer/MultiplayerApiOutput.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace ModernWarfare.Net.Models.Multiplayer
 {
-    public class ModernWarfareApiOutput
+    public class MultiplayerApiOutput
     {
         [JsonProperty("data")]
         public Data Data { get; set; }

--- a/src/ModernWarfare.Net/Models/Multiplayer/MultiplayerStats.cs
+++ b/src/ModernWarfare.Net/Models/Multiplayer/MultiplayerStats.cs
@@ -2,7 +2,7 @@
 
 namespace ModernWarfare.Net.Models.Multiplayer
 {
-    public class Stats
+    public class MultiplayerStats
     {
         [JsonProperty("kDRatio")]
         public Information KDRatio { get; set; }

--- a/src/ModernWarfare.Net/Models/Multiplayer/Segment.cs
+++ b/src/ModernWarfare.Net/Models/Multiplayer/Segment.cs
@@ -15,6 +15,6 @@ namespace ModernWarfare.Net.Models.Multiplayer
         public DateTimeOffset ExpiryDate { get; set; }
 
         [JsonProperty("stats")]
-        public Stats Stats { get; set; }
+        public MultiplayerStats Stats { get; set; }
     }
 }

--- a/src/ModernWarfare.Net/Models/Warzone/LevelStats.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/LevelStats.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+
+namespace ModernWarfare.Net.Models.Warzone
+{
+    public class LevelStats
+    {
+        [JsonProperty("percentile")]
+        public double Percentile { get; set; }
+        [JsonProperty("displayName")]
+        public string DisplayName { get; set; }
+        [JsonProperty("displayCategory")]
+        public string DisplayCategory { get; set; }
+        [JsonProperty("category")]
+        public string Category { get; set; }
+        [JsonProperty("metaData")]
+        public Models.Metadata MetaData { get; set; }
+        [JsonProperty("value")]
+        public double Value { get; set; }
+        [JsonProperty("displayValue")]
+        public string DisplayValue { get; set; }
+        [JsonProperty("displayType")]
+        public string DisplayType { get; set; }
+    }
+}

--- a/src/ModernWarfare.Net/Models/Warzone/LifetimeWarzoneStats.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/LifetimeWarzoneStats.cs
@@ -1,0 +1,9 @@
+﻿namespace ModernWarfare.Net.Models.Warzone
+{
+    public class LifetimeWarzoneStats : WarzoneStats
+    {
+        public LevelStats Level { get; set; }
+        public LevelStats LevelXpTotal { get; set; }
+        public LevelStats LevelProgression { get; set; }
+    }
+}

--- a/src/ModernWarfare.Net/Models/Warzone/Metadata.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/Metadata.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace ModernWarfare.Net.Models.Warzone
 {

--- a/src/ModernWarfare.Net/Models/Warzone/Segment.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/Segment.cs
@@ -15,6 +15,6 @@ namespace ModernWarfare.Net.Models.Warzone
         public DateTimeOffset ExpiryDate { get; set; }
 
         [JsonProperty("stats")]
-        public Stats Stats { get; set; }
+        public WarzoneStats Stats { get; set; }
     }
 }

--- a/src/ModernWarfare.Net/Models/Warzone/WarzoneApiOutput.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/WarzoneApiOutput.cs
@@ -2,7 +2,7 @@
 
 namespace ModernWarfare.Net.Models.Warzone
 {
-    public class ModernWarfareApiOutput
+    public class WarzoneApiOutput
     {
         [JsonProperty("data")]
         public Data Data { get; set; }

--- a/src/ModernWarfare.Net/Models/Warzone/WarzoneStats.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/WarzoneStats.cs
@@ -2,7 +2,7 @@
 
 namespace ModernWarfare.Net.Models.Warzone
 {
-    public class Stats
+    public class WarzoneStats
     {
         [JsonProperty("kills")]
         public Information Kills { get; set; }

--- a/src/ModernWarfare.Net/Models/Warzone/WarzoneStatsView.cs
+++ b/src/ModernWarfare.Net/Models/Warzone/WarzoneStatsView.cs
@@ -1,0 +1,16 @@
+﻿namespace ModernWarfare.Net.Models.Warzone
+{
+    public class WarzoneStatsView
+    {
+        public WarzoneStatsView(LifetimeWarzoneStats lifetimeStats, WarzoneStats brStats, WarzoneStats plunderStats)
+        {
+            LifetimeStats = lifetimeStats;
+            BattleRoyalStats = brStats;
+            PlunderStats = plunderStats;
+        }
+
+        public LifetimeWarzoneStats LifetimeStats { get; }
+        public WarzoneStats BattleRoyalStats { get; }
+        public WarzoneStats PlunderStats { get; }
+    }
+}

--- a/src/ModernWarfare.NetTests/PlatformTests.cs
+++ b/src/ModernWarfare.NetTests/PlatformTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Threading.Tasks;
-using ModernWarfare.Net.Models.Enums;
+﻿using ModernWarfare.Net.Models.Enums;
 using Xunit;
 
 namespace ModernWarfare.NetTests
 {
+    [Trait("Platform", "Enum Extensions")]
     public class PlatformTests
     {
         [Theory]
@@ -11,7 +11,7 @@ namespace ModernWarfare.NetTests
         [InlineData(Platform.Activision, "atvi")]
         [InlineData(Platform.PSN, "psn")]
         [InlineData(Platform.XBL, "xbl")]
-        public void ToApiString_EnumsProvided_GiveBackCorrectString(Platform platform, string platformString)
+        public void ToApiString_EnumsProvided_GivesBackPropperlyFormattedPlatformForAPI(Platform platform, string expectedString)
         {
             //Arrange
             string requestPlatform;
@@ -20,28 +20,21 @@ namespace ModernWarfare.NetTests
             requestPlatform = platform.ToApiString();
 
             //Assert
-            Assert.Equal(platformString, requestPlatform);
+            Assert.Equal(expectedString, requestPlatform);
         }
 
         [Theory]
-        [InlineData(Platform.BattleNet, "Timmmy#21485")]
-        [InlineData(Platform.Activision, "khayamimtiaz")]
-        [InlineData(Platform.PSN, "igman19")]
-        [InlineData(Platform.XBL, "AuTxPHIL")]
-        public void ToValidUsername_PlatformAndValidUsernameProvided_GiveBackConvertedUsername(Platform platform, string username)
+        [InlineData(Platform.BattleNet, "Timmmy#21485", "Timmmy%2321485")]
+        [InlineData(Platform.Activision, "khayamimtiaz", "khayamimtiaz")]
+        [InlineData(Platform.PSN, "igman19", "igman19")]
+        [InlineData(Platform.XBL, "AuTxPHIL", "AuTxPHIL")]
+        public void ToValidUsername_GivesBackPropperlyFormattedUsernameForAPI(Platform platform, string username, string expected)
         {
             //Act
             string newUsername = platform.ToValidUsername(username);
 
             //Assert
-            if (platform == Platform.BattleNet)
-            {
-                Assert.Equal("Timmmy%2321485", newUsername);
-            }
-            else
-            {
-                Assert.NotEmpty(newUsername);
-            }
+            Assert.Equal(expected, newUsername);
         }
     }
 }


### PR DESCRIPTION
## 🤔 What changed?
Tests refactored to remove condition.
GetWarzoneStatsAsync now returns a view model type rather than the type we deserialise into.
This type is built by us so the user of the library has a neater type when they request the warzone stats for thier user.

## ℹ️ Feedback
General sanity check and ensure it works in a test app. 